### PR TITLE
state 저장 localStorage 에서 sessionStorage로 변경

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -8,7 +8,7 @@ import { composeWithDevTools } from 'redux-devtools-extension';
 import rootReducer from '@store/store';
 import Router from './route';
 
-const curProject = localStorage.getItem('curProject');
+const curProject = sessionStorage.getItem('curProject');
 const persistedState = curProject ? JSON.parse(curProject) : {};
 const initialState = { curProjectReducer: persistedState };
 
@@ -20,7 +20,7 @@ const store = createStore(
 
 store.subscribe(() => {
   const projectId = store.getState().curProjectReducer;
-  localStorage.setItem('curProject', JSON.stringify(projectId));
+  sessionStorage.setItem('curProject', JSON.stringify(projectId));
 });
 
 const App: FunctionComponent = () => (


### PR DESCRIPTION
### 변경 이유
- 여러 개의 tab을 켜놓는다고 생각했을 때 모든 탭에서 같은 프로젝트를 가리키지 않아야하므로 sessionStorage가 더 적합하다고 판단.
- 브라우저 창을 껐을 때도 유지해야하는 상태가 아니라고 판단.

### 변경사항
- current project sessionStorage에 저장하도록 변경

### 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트
